### PR TITLE
Native Instruments MIDI protocol, implement additional actions

### DIFF
--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -25,17 +25,52 @@ const unsigned char CMD_GOODBYE = 0x02;
 const unsigned char CMD_PLAY = 0x10;
 const unsigned char CMD_RESTART = 0x11;
 const unsigned char CMD_REC = 0x12;
+const unsigned char CMD_COUNT = 0x13;
 const unsigned char CMD_STOP = 0x14;
+const unsigned char CMD_CLEAR = 0x15;
+const unsigned char CMD_LOOP = 0x16;
 const unsigned char CMD_METRO = 0x17;
 const unsigned char CMD_TEMPO = 0x18;
 const unsigned char CMD_UNDO = 0x20;
 const unsigned char CMD_REDO = 0x21;
+const unsigned char CMD_QUANTIZE = 0x22;
+const unsigned char CMD_AUTO = 0x23;
 const unsigned char CMD_NAV_TRACKS = 0x30;
+const unsigned char CMD_NAV_BANKS = 0x31;
+const unsigned char CMD_NAV_CLIPS = 0x32;
+const unsigned char CMD_NAV_SCENES = 0x33;
 const unsigned char CMD_MOVE_TRANSPORT = 0x34;
+const unsigned char CMD_MOVE_LOOP = 0x35;
 const unsigned char CMD_TRACK_AVAIL = 0x40;
 const unsigned char CMD_SEL_TRACK_PARAMS_CHANGED = 0x41;
 const unsigned char CMD_TRACK_SELECTED = 0x42;
+const unsigned char CMD_TRACK_MUTED = 0x43;
+const unsigned char CMD_TRACK_SOLOED = 0x44;
+const unsigned char CMD_TRACK_ARMED = 0x45;
+const unsigned char CMD_TRACK_VOLUME_CHANGED = 0x46;
+const unsigned char CMD_TRACK_PAN_CHANGED = 0x47;
 const unsigned char CMD_TRACK_NAME = 0x48;
+const unsigned char CMD_TRACK_VU = 0x49;
+const unsigned char CMD_KNOB_VOLUME1 = 0x50;
+const unsigned char CMD_KNOB_VOLUME2 = 0x51;
+const unsigned char CMD_KNOB_VOLUME3 = 0x52;
+const unsigned char CMD_KNOB_VOLUME4 = 0x53;
+const unsigned char CMD_KNOB_VOLUME5 = 0x54;
+const unsigned char CMD_KNOB_VOLUME6 = 0x55;
+const unsigned char CMD_KNOB_VOLUME7 = 0x56;
+const unsigned char CMD_KNOB_VOLUME8 = 0x57;
+const unsigned char CMD_KNOB_PAN1 = 0x58;
+const unsigned char CMD_KNOB_PAN2 = 0x59;
+const unsigned char CMD_KNOB_PAN3 = 0x5a;
+const unsigned char CMD_KNOB_PAN4 = 0x5b;
+const unsigned char CMD_KNOB_PAN5 = 0x5c;
+const unsigned char CMD_KNOB_PAN6 = 0x5d;
+const unsigned char CMD_KNOB_PAN7 = 0x5e;
+const unsigned char CMD_KNOB_PAN8 = 0x5f;
+const unsigned char CMD_CHANGE_VOLUME = 0x64;
+const unsigned char CMD_CHANGE_PAN = 0x65;
+const unsigned char CMD_TOGGLE_MUTE = 0x66;
+const unsigned char CMD_TOGGLE_SOLO = 0x67;
 
 const unsigned char TRTYPE_UNSPEC = 1;
 
@@ -90,6 +125,12 @@ class NiMidiSurface: public BaseSurface {
 		if (event->midi_message[0] != MIDI_CC) {
 			return;
 		}
+		ostringstream s;
+		s << "MIDI message " << showbase << hex
+			<< (int)event->midi_message[0] << " "
+			<< (int)event->midi_message[1] << " "
+			<< (int)event->midi_message[2] << endl;
+		ShowConsoleMsg(s.str().c_str());
 		unsigned char& value = event->midi_message[2];
 		switch (event->midi_message[1]) { // Command
 			case CMD_HELLO:

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -105,6 +105,15 @@ class NiMidiSurface: public BaseSurface {
 	virtual void SetTrackListChange() override {
 	}
 
+	virtual void SetSurfaceVolume(MediaTrack *trackid, double volume) override {
+	}
+
+	virtual void SetSurfacePan(MediaTrack *trackid, double pan) override {
+	}
+
+	virtual void SetSurfaceMute(MediaTrack *trackid, bool mute) override {
+	}
+
 	virtual void SetSurfaceSelected(MediaTrack* track, bool selected) override {
 		if (selected) {
 			int id = CSurf_TrackToID(track, false);
@@ -118,6 +127,12 @@ class NiMidiSurface: public BaseSurface {
 			this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0,
 				getKkInstanceName(track));
 		}
+	}
+
+	virtual void SetSurfaceSolo(MediaTrack *trackid, bool solo) override {
+	}
+
+	virtual void SetSurfaceRecArm(MediaTrack *trackid, bool recarm) override {
 	}
 
 	protected:
@@ -189,7 +204,13 @@ class NiMidiSurface: public BaseSurface {
 			this->_sendSysex(CMD_TRACK_AVAIL, TRTYPE_UNSPEC, numInBank);
 			int selected = *(int*)GetSetMediaTrackInfo(track, "I_SELECTED", nullptr);
 			this->_sendSysex(CMD_TRACK_SELECTED, selected, numInBank);
-			// todo: muted, soloed, armed, volume text, pan text
+			int soloState = *(int*)GetSetMediaTrackInfo(track, "I_SOLO", nullptr);
+			this->_sendSysex(CMD_TRACK_SOLOED, (soloState==0) ? 0 : 1, numInBank);
+			bool muted = *(bool*)GetSetMediaTrackInfo(track, "B_MUTE", nullptr);
+			this->_sendSysex(CMD_TRACK_MUTED, muted ? 1 : 0, numInBank);
+			int armed = *(int*)GetSetMediaTrackInfo(track, "I_RECARM", nullptr);
+			this->_sendSysex(CMD_TRACK_ARMED, armed, numInBank);
+			// todo: volume text, pan text
 			char* name = (char*)GetSetMediaTrackInfo(track, "P_NAME", nullptr);
 			if (!name) {
 				name = "";

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -102,20 +102,6 @@ class NiMidiSurface: public BaseSurface {
 		return "Komplete Kontrol S-series Mk2/A-series/M-series";
 	}
 
-	virtual void SetTrackListChange() override {
-	}
-
-	virtual void SetSurfaceVolume(MediaTrack *trackid, double volume) override {
-		// todo: update volume text if applicable
-	}
-
-	virtual void SetSurfacePan(MediaTrack *trackid, double pan) override {
-		// todo: update pantext if applicable
-	}
-
-	virtual void SetSurfaceMute(MediaTrack *trackid, bool mute) override {
-	}
-
 	virtual void SetSurfaceSelected(MediaTrack* track, bool selected) override {
 		if (selected) {
 			int id = CSurf_TrackToID(track, false);
@@ -129,12 +115,6 @@ class NiMidiSurface: public BaseSurface {
 			this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0,
 				getKkInstanceName(track));
 		}
-	}
-
-	virtual void SetSurfaceSolo(MediaTrack *trackid, bool solo) override {
-	}
-
-	virtual void SetSurfaceRecArm(MediaTrack *trackid, bool recarm) override {
 	}
 
 	protected:

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -154,11 +154,18 @@ class NiMidiSurface: public BaseSurface {
 			case CMD_PLAY:
 				CSurf_OnPlay();
 				break;
+			case CMD_RESTART:
+				CSurf_GoStart();
+				CSurf_OnPlay();
+				break;
 			case CMD_REC:
 				CSurf_OnRecord();
 				break;
 			case CMD_STOP:
 				CSurf_OnStop();
+				break;
+			case CMD_LOOP:
+				// Find out how to implement. Probably set start point at first press, and point on second press.
 				break;
 			case CMD_METRO:
 				Main_OnCommand(40364, 0); // Options: Toggle metronome
@@ -171,6 +178,9 @@ class NiMidiSurface: public BaseSurface {
 				break;
 			case CMD_REDO:
 				Main_OnCommand(40030, 0); // Edit: Redo
+				break;
+			case CMD_QUANTIZE:
+				// Todo, probably use something like SWS/FNG: Quantize item positions and MIDI note positions to grid
 				break;
 			case CMD_NAV_TRACKS:
 				// Value is -1 or 1.

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -163,8 +163,8 @@ class NiMidiSurface: public BaseSurface {
 			case CMD_NAV_CLIPS:
 				// Value is -1 or 1.
 				Main_OnCommand(value == 1 ?
-					40417 : // Item navigation: Select and move to next item
-					40416, // Item navigation: Select and move to previous item
+					40173 : // Markers: Go to next marker/project end
+					40172, // Markers: Go to previous marker/project start
 				0);
 				break;
 			case CMD_MOVE_TRANSPORT:

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -241,14 +241,14 @@ class NiMidiSurface: public BaseSurface {
 		int numInBank = command - CMD_KNOB_VOLUME1 + 1;
 		MediaTrack* track = CSurf_TrackFromID(numInBank + this->_bankStart, false);
 		if (!track) return;
-		CSurf_SetSurfaceVolume(track,CSurf_OnVolumeChange(track,value * 0.1,true),NULL);
+		CSurf_SetSurfaceVolume(track, CSurf_OnVolumeChange(track, value * 0.1, true), nullptr);
 	}
 
 	void _onKnobPanChange(unsigned char command, signed char value) {
 		int numInBank = command - CMD_KNOB_VOLUME1 + 1;
 		MediaTrack* track = CSurf_TrackFromID(numInBank + this->_bankStart, false);
 		if (!track) return;
-		CSurf_SetSurfacePan(track,CSurf_OnPanChange(track,value*1.0,true),NULL);
+		CSurf_SetSurfacePan(track, CSurf_OnPanChange(track, value * 1.0, true), nullptr);
 	}
 
 	void _sendCc(unsigned char command, unsigned char value) {

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -27,6 +27,7 @@
 #define REAPERAPI_WANT_TrackFX_GetCount
 #define REAPERAPI_WANT_TrackFX_GetFXName
 #define REAPERAPI_WANT_TrackFX_GetParamName
+#define REAPERAPI_WANT_CSurf_GoStart
 #define REAPERAPI_WANT_CSurf_OnStop
 #define REAPERAPI_WANT_CSurf_OnRecord
 #define REAPERAPI_WANT_Main_OnCommand

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -33,6 +33,10 @@
 #define REAPERAPI_WANT_Main_OnCommand
 #define REAPERAPI_WANT_CSurf_ScrubAmt
 #define REAPERAPI_WANT_GetSetMediaTrackInfo
+#define REAPERAPI_WANT_CSurf_SetSurfaceVolume
+#define REAPERAPI_WANT_CSurf_SetSurfacePan
+#define REAPERAPI_WANT_CSurf_OnVolumeChange
+#define REAPERAPI_WANT_CSurf_OnPanChange
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
This is a first pull request to start with, which implements the following:

* Item navigation with the multidirectional rotor after pressing the track button, pushing left/right
* After pressing the track button, the 8 knob change the respective track volumes of the currently selected bank. Panning should also be there, but I haven't yet found out how to do that from the M32 I have
* When changing banks, the appropriate solo, mute and armed states per track are now sent to the unit. I assume these are shown on the display of MK2 devices, so I can't test this myself.
* Pressing restart (shift+play) should now move back to the start of the project, haven't yet tested this myself though
