### PR TITLE
Peak meters calibrated pull

### DIFF
--- a/include/reaper/WDL/db2val.h
+++ b/include/reaper/WDL/db2val.h
@@ -1,0 +1,17 @@
+#ifndef _WDL_DB2VAL_H_
+#define _WDL_DB2VAL_H_
+
+#include <math.h>
+
+#define TWENTY_OVER_LN10 8.6858896380650365530225783783321
+#define LN10_OVER_TWENTY 0.11512925464970228420089957273422
+#define DB2VAL(x) exp((x)*LN10_OVER_TWENTY)
+static inline double VAL2DB(double x)
+{
+  if (x < 0.0000000298023223876953125) return -150.0;
+  double v=log(x)*TWENTY_OVER_LN10;
+  return v<-150.0?-150.0:v;
+}
+
+
+#endif

--- a/readme.md
+++ b/readme.md
@@ -1,69 +1,22 @@
 # ReaKontrol
+- Fork of the excellent ReaKontrol repository published by James Teh: https://github.com/jcsteh/reaKontrol
+- Author: brumbear@pacificpeaks & other contributors
+- Copyright: 2019 and later Pacific Peaks Studio, see individual copyrights in source code
+- License: GNU General Public License version 2.0.
+- License Notes: As the original work is published under GPLv2 the updated programs are also licensed under GPLv2. May be updated to GPLv3 if copyright holder of original work agrees to update too.
 
-- Author: James Teh &lt;jamie@jantrid.net&gt; & other contributors
-- Copyright: 2018-2019 James Teh & other contributors
-- License: GNU General Public License version 2.0
+## Feature Integration
+This fork is mainly a development branch aiming to continuously add functionality to ReaKontrol. 
+- New features will be merged into this fork's master @ https://github.com/brummbrum/reaKontrol
+- Testing and calibration is done with NI S-Series Mk2 Komplete Kontrol Keyboard.
 
-ReaKontrol is a [REAPER](https://www.reaper.fm/) extension which provides advanced host integration for [Native Instruments Komplete Kontrol keyboards](https://www.native-instruments.com/en/products/komplete/keyboards/).
-It currently only runs on Windows and requires REAPER 5.92 or later.
+## Upstream Integration
+- New features are also offered to the upstream master @ https://github.com/jcsteh/reaKontrol
+- Some updated features may or may not be merged with the upstream master due to different priorities
+- The sequence in which new features are published may be different between this fork and the upstream master due to different priorities
 
-ReaKontrol supports Komplete Kontrol S-series Mk2, A-series and M-series keyboards.
-While some initial work has been done to support S-series Mk1 keyboards, this is not yet functional.
+## Which fork should you use?
+- To the extent that features are integrated into the upstream master it is recommended to stick to the original branch @ https://github.com/jcsteh/reaKontrol
 
-## Supported Functionality
-The following functionality is currently supported:
-
-- Focus follow; i.e. the Komplete Kontrol instance is switched automatically when a track is selected.
-- Transport buttons: Play, Restart, Record, Stop, Metronome, Tempo
-- Edit buttons: Undo, Redo
-- Track navigation
-- Clip navigation: moves between project markers
-- Mixer view: volume/pan adjustment with the 8 knobs
-- The track name and mute, solo and armed states are displayed as appropriate.
-
-## Download and Installation
-For now, there is no installer.
-You can [download the latest build of the extension here](https://osara.reaperaccessibility.com/reaper_kontrol.dll).
-
-Once downloaded, simply copy the `reaper_kontrol.dll` file you downloaded to the `%appdata%\REAPER\UserPlugins` folder using Windows File Explorer.
-You can get to this folder by copying the name above and pasting it into either the Windows Run dialog or the File Explorer address bar.
-
-You do not need to add a control surface or perform any other configuration in REAPER.
-Komplete Kontrol Host integration should work as soon as you start REAPER with a Komplete Kontrol keyboard connected.
-
-## Reporting Issues
-Issues should be reported [on GitHub](https://github.com/jcsteh/reaKontrol/issues).
-
-## Building
-This section is for those interested in building ReaKontrol from source code.
-
-### Getting the Source Code
-The ReaKontrol Git repository is located at https://github.com/jcsteh/reaKontrol.git.
-You can clone it with the following command, which will place files in a directory named reaKontrol:
-
-```
-git clone https://github.com/jcsteh/reaKontrol.git
-```
-
-### Dependencies
-To build ReaKontrol, you will need:
-
-- Microsoft Visual Studio 2017 Community:
-	* Visual Studio 2019 is not yet supported.
-	* [Download Visual Studio 2017 Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15)
-	* When installing Visual Studio, you need to enable the following:
-		- On the Workloads tab, in the Windows group: Desktop development with C++
-- Python, version 2.7:
-	* This is needed by SCons.
-	* Python 3 and later are not yet supported.
-	* [Download Python](https://www.python.org/downloads/)
-- [SCons](https://www.scons.org/), version 3.0.4 or later:
-	* Once Python is installed, you should be able to install SCons by simply running this at the command line: `pip install scons`
-
-### How to Build
-To build ReaKontrol, from a command prompt, simply change to the ReaKontrol checkout directory and run `scons`.
-The resulting dll can be found in the `build` directory.
-
-## Contributors
-- James Teh
-- Leonard de Ruijter
+## Build instructions and additional description
+- Please refer to the original branch @ https://github.com/jcsteh/reaKontrol

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ BaseSurface::~BaseSurface() {
 }
 
 void BaseSurface::Run() {
+	this->_vuMixerUpdate(); // TEST
 	if (!this->_midiIn) {
 		return;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ BaseSurface::~BaseSurface() {
 }
 
 void BaseSurface::Run() {
-	this->_vuMixerUpdate(); // TEST
+	this->_peakMixerUpdate(); // ToDo: Maybe update only every 2nd call to save CPU?
 	if (!this->_midiIn) {
 		return;
 	}

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -103,6 +103,10 @@ class McuSurface: public BaseSurface {
 		this->_sendRaw(message);
 	}
 
+	void _vuMixerUpdate() override {
+		// DUMMY. This has to to with the current file structure. Maybe better to move Run() callback into niMidi.cpp and mcu.cpp
+	}
+
 	private:
 	void _sendRaw(const string& message) {
 		// MIDI_event_t includes 4 bytes for the message, but we need more.

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -103,8 +103,8 @@ class McuSurface: public BaseSurface {
 		this->_sendRaw(message);
 	}
 
-	void _vuMixerUpdate() override {
-		// DUMMY. This has to to with the current file structure. Maybe better to move Run() callback into niMidi.cpp and mcu.cpp
+	void _peakMixerUpdate() override {
+		// DUMMY. Currently only implemented for niMiDi (Mk2). Maybe better to move Run() callback into niMidi.cpp and mcu.cpp?
 	}
 
 	private:

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -91,6 +91,7 @@ signed char convertSignedMidiValue(unsigned char value) {
 
 // The following conversion functions (C) 2006-2008 Cockos Incorporated
 // Note: Keep static for now
+// Eliminate those that will eventually not be used (e.g. volToChar)
 static double charToVol(unsigned char val)
 {
 	double pos = ((double)val*1000.0) / 127.0;
@@ -99,7 +100,7 @@ static double charToVol(unsigned char val)
 
 }
 
-static  unsigned char volToChar(double vol)
+static unsigned char volToChar(double vol)
 {
 	double d = (DB2SLIDER(VAL2DB(vol))*127.0 / 1000.0);
 	if (d < 0.0)d = 0.0;
@@ -129,11 +130,27 @@ static unsigned char panToChar(double pan)
 }
 // End of conversion functions (C) 2006-2008 Cockos Incorporated
 
-static  unsigned char vuPeakToChar(double vol)
+static double KK_Mk2_Display_Transform(double x_in)
 {
-	double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Specific calibration for KK Mk2
-	if (d < 0.0)d = 0.0; // Consider setting it to 0.5 because of KK special interpretation of the 0
-	else if (d > 127.0)d = 127.0; // Consider setting it to 126.5
+	// Scale from approx -92dB (MIDI value = #1) to +5dB (MIDI value = #127)
+	// IMPORTANT: KK Mk2 meter scale intervals are NOT linear!
+	// Midi #107 = 0dB, #68 = -12dB, #38 = -24dB, #16 = -48dB
+	double temp;
+	temp = 0.0;
+	double a = 1.4188776691241778E+00;
+	double b = 4.1718814064260904E-03;
+	double c = 1.3365905415325063E+01;
+	temp = pow(a + b * x_in, c);
+	return temp;
+}
+
+static unsigned char peakToChar(double vol)
+{
+	double d = KK_Mk2_Display_Transform(VAL2DB(vol)); // Non-linear calibration to KK Mk2
+													  // For a faster less CPU intensive calculation:
+													  // double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Approximate, linear calibration for KK Mk2
+	if (d < 0.0)d = 0.0; 
+	else if (d > 127.0)d = 127.0; 
 
 	return (unsigned char)(d + 0.5);
 }
@@ -240,6 +257,12 @@ class NiMidiSurface: public BaseSurface {
 				break;
 			case CMD_NAV_TRACKS:
 				// Value is -1 or 1.
+				// ---------------------------- ISSUE --------------------------------------------------------
+				// Reaper's built in actions will not reliably got to next/previous track relative to currently SELECTED track!
+				// Rather, these actions are relative to last TOUCHED track. E.g. if volume fader is changed on a non selected track
+				// and then we navigate the new track will be next to the track with the volume fader touched
+				// => Use dedicated track navigation via API, not actions
+				// -------------------------------------------------------------------------------------------
 				Main_OnCommand(value == 1 ?
 					40285 : // Track: Go to next track
 					40286, // Track: Go to previous track
@@ -299,20 +322,14 @@ class NiMidiSurface: public BaseSurface {
 		}
 	}
 
-	void _vuMixerUpdate() override {
-		// VU meters		
-		char vuBank[17]; // INIT??? = { 0 };
-		int j = 0;
-		double peakValue = 0;
+	void _peakMixerUpdate() override {
+		// Peak meters. Note: Reaper reports peak, NOT VU	
 
-		//ToDo: Peak levels of muted tracks should NOT be polled at all
-		//ToDo: Calibration to 0dB. If we calibrate in conversion function (~900.0 vs 1000.0 we are off at low levels)
-		//       maybe calibrate before calling conversion or in first WDL conversion VAL2DB
-		//       TRY FIRST: Use directly VAL2DB conversion
-		//ToDo: Clean up array Initialization , stop byte, array size, CMD_SEL_TRACK_PARAMS_CHANGED
-		
-		vuBank[0] = 1; // there will alway be a master track
-		vuBank[1] = 1;
+		// ToDo: Peak Hold in KK display shall be erased when changing bank or when no signal at all
+		// ToDo: Explore the necessity of CMD_SEL_TRACK_PARAMS_CHANGED and if last parameter (string) shall be the last track in bank
+		char peakBank[17] = { 0 }; // For some reason there must be this additional char peakBank[16] and it must be set to 0
+		int j = 0;
+		double peakValue = 0;		
 		int numInBank = 0;
 		int bankEnd = this->_bankStart + BANK_NUM_TRACKS - 1;
 		int numTracks = CSurf_NumTracks(false); // If we ever want to show just MCP tracks in KK Mixer View (param) must be (true)
@@ -325,28 +342,38 @@ class NiMidiSurface: public BaseSurface {
 				break;
 			}
 			j = 2 * numInBank;
-			peakValue = Track_GetPeakInfo(track, 0); // left channel
-			if (peakValue == 0) {
-				// No log conversion necessary
-				vuBank[j] = 1; // if 0 then channels further to the right are ignored by KK display
+			// Muted tracks still report peak levels => ignore these
+			if (*(bool*)GetSetMediaTrackInfo(track, "B_MUTE", nullptr)) {
+				peakBank[j] = 1;
+				peakBank[j+1] = 1;
 			}
 			else {
-				vuBank[j] = vuPeakToChar(peakValue);
-				if (vuBank[j] == 0) { vuBank[j] = 1; } // if 0 then channels further to the right are ignored by KK display
+				peakValue = Track_GetPeakInfo(track, 0); // left channel
+				if (peakValue < 0.0000000298023223876953125) {
+					// No log conversion necessary if < -150dB
+					peakBank[j] = 1; // if 0 then channels further to the right are ignored by KK display
+				}
+				else {
+					peakBank[j] = peakToChar(peakValue);
+					if (peakBank[j] == 0) { peakBank[j] = 1; } // if 0 then channels further to the right are ignored by KK display
+				}
+				peakValue = Track_GetPeakInfo(track, 1); // right channel
+				if (peakValue < 0.0000000298023223876953125) {
+					// No log conversion necessary if < -150dB
+					peakBank[j + 1] = 1; // if 0 then channels further to the right are ignored by KK display
+				}
+				else {
+					peakBank[j + 1] = peakToChar(peakValue);
+					if (peakBank[j + 1] == 0) { peakBank[j + 1] = 1; } // if 0 then channels further to the right are ignored by KK display
+				}
 			}
-			peakValue = Track_GetPeakInfo(track, 1); // right channel
-			if (peakValue == 0) {
-				// No log conversion necessary
-				vuBank[j+1] = 1; // if 0 then channels further to the right are ignored by KK display
-			}
-			else {
-				vuBank[j+1] = vuPeakToChar(peakValue);
-				if (vuBank[j+1] == 0) { vuBank[j+1] = 1; } // if 0 then channels further to the right are ignored by KK display
-			}
-		}
-		vuBank[16] = 0; // JUST A TEST - it seems a sort of stop bit/byte is needed here. See also initialization above
-		this->_sendSysex(CMD_TRACK_VU, 2, 0, vuBank); // do the params have anything to do with calibration?
-		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all? Maybe we have to reference last track in bank to indicate end of updates?
+		}	
+		this->_sendSysex(CMD_TRACK_VU, 2, 0, peakBank); 
+		/*
+		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all?
+															  // Maybe we have to reference last track in bank to indicate end of updates?
+															  // Or, if the meter for only one track shall be changed this is indicated here
+		*/
 	}
 
 	private:
@@ -404,9 +431,9 @@ class NiMidiSurface: public BaseSurface {
 		}
 		MediaTrack* track = CSurf_TrackFromID(id, false);
 		int iSel = 1; // "Select"
-		// If we rather wanted to "Toggle" than just "Select" we would use:
-		// int iSel = 0;
-		// int iSel = *(int*)GetSetMediaTrackInfo(track, "I_SELECTED", nullptr) ? 0 : 1; 
+					  // If we rather wanted to "Toggle" than just "Select" we would use:
+					  // int iSel = 0;
+					  // int iSel = *(int*)GetSetMediaTrackInfo(track, "I_SELECTED", nullptr) ? 0 : 1; 
 		ClearSelected(); 
 		GetSetMediaTrackInfo(track, "I_SELECTED", &iSel);		
 	}

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -256,7 +256,7 @@ class NiMidiSurface: public BaseSurface {
 
 	void _allMixerUpdate() {
 		int numInBank = 0;
-		int bankEnd = this->_bankStart + BANK_NUM_TRACKS;
+		int bankEnd = this->_bankStart + BANK_NUM_TRACKS - 1; // avoid ambiguity: track counting always zero based
 		int numTracks = CSurf_NumTracks(false); // If we ever want to show just MCP tracks in KK Mixer View (param) must be (true)
 		if (bankEnd > numTracks) {
 			bankEnd = numTracks;
@@ -329,7 +329,7 @@ class NiMidiSurface: public BaseSurface {
 		if (!track) {
 			return;
 		}
-		CSurf_OnVolumeChange(track, dvalue * 0.01, true); 
+		CSurf_OnVolumeChange(track, dvalue * 0.007874, true); // scaling by dividing by 127 (0.007874) 
 	}
 
 	void _onKnobPanChange(unsigned char command, signed char value) {
@@ -339,7 +339,7 @@ class NiMidiSurface: public BaseSurface {
 		if (!track) {
 			return;
 		}
-		CSurf_OnPanChange(track, dvalue * 0.001, true);
+		CSurf_OnPanChange(track, dvalue * 0.00098425, true); // scaling by dividing by 127*8 (0.00098425)
 	}
 
 	void _sendCc(unsigned char command, unsigned char value) {

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -7,7 +7,6 @@
  * License: GNU General Public License version 2.0
  */
 
-#define DEBUG_DIAGNOSTICS
 #define BASIC_DIAGNOSTICS
 
 #include <string>
@@ -214,17 +213,6 @@ class NiMidiSurface: public BaseSurface {
 		unsigned char& command = event->midi_message[1];
 		unsigned char& value = event->midi_message[2];
 		
-#ifdef DEBUG_DIAGNOSTICS
-		ostringstream s;
-		s << "Diagnostic: MIDI " << showbase << hex
-			<< (int)event->midi_message[0] << " "
-			<< (int)event->midi_message[1] << " "
-			<< (int)event->midi_message[2] << " Focus Track "
-			<< g_trackInFocus << " Bank Start "
-			<< this->_bankStart << endl;
-		ShowConsoleMsg(s.str().c_str());
-#endif
-
 		switch (command) {
 			case CMD_HELLO:
 				this->_protocolVersion = value;

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -262,6 +262,7 @@ class NiMidiSurface: public BaseSurface {
 				// Rather, these actions are relative to last TOUCHED track. E.g. if volume fader is changed on a non selected track
 				// and then we navigate the new track will be next to the track with the volume fader touched
 				// => Use dedicated track navigation via API, not actions
+				// OK: Ready for pulling a fix
 				// -------------------------------------------------------------------------------------------
 				Main_OnCommand(value == 1 ?
 					40285 : // Track: Go to next track

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -132,8 +132,8 @@ static unsigned char panToChar(double pan)
 static  unsigned char vuPeakToChar(double vol)
 {
 	double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Specific calibration for KK Mk2
-	if (d < 0.0)d = 0.0;
-	else if (d > 127.0)d = 127.0;
+	if (d < 0.0)d = 0.0; // Consider setting it to 0.5 because of KK special interpretation of the 0
+	else if (d > 127.0)d = 127.0; // Consider setting it to 126.5
 
 	return (unsigned char)(d + 0.5);
 }
@@ -345,7 +345,7 @@ class NiMidiSurface: public BaseSurface {
 			}
 		}
 		vuBank[16] = 0; // JUST A TEST - it seems a sort of stop bit/byte is needed here. See also initialization above
-		this->_sendSysex(CMD_TRACK_VU, 2, 2, vuBank); // do the params have anything to do with calibration?
+		this->_sendSysex(CMD_TRACK_VU, 2, 0, vuBank); // do the params have anything to do with calibration?
 		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all? Maybe we have to reference last track in bank to indicate end of updates?
 	}
 

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -62,7 +62,7 @@ class BaseSurface: public IReaperControlSurface {
 	midi_Input* _midiIn = nullptr;
 	midi_Output* _midiOut = nullptr;
 	virtual void _onMidiEvent(MIDI_event_t* event) = 0;
-	virtual void _vuMixerUpdate() = 0;
+	virtual void _peakMixerUpdate() = 0;
 };
 
 IReaperControlSurface* createNiMidiSurface(int inDev, int outDev);

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -37,6 +37,7 @@
 #define REAPERAPI_WANT_CSurf_SetSurfacePan
 #define REAPERAPI_WANT_CSurf_OnVolumeChange
 #define REAPERAPI_WANT_CSurf_OnPanChange
+#define REAPERAPI_WANT_GetPlayState
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -41,8 +41,11 @@
 #define REAPERAPI_WANT_CSurf_OnPanChange
 #define REAPERAPI_WANT_GetPlayState
 #define REAPERAPI_WANT_Track_GetPeakInfo
+#define REAPERAPI_WANT_DB2SLIDER
+#define REAPERAPI_WANT_SLIDER2DB
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
+#include <reaper/WDL/db2val.h>
 
 const std::string getKkInstanceName(MediaTrack* track, bool stripPrefix=false);
 

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -18,9 +18,11 @@
 #define REAPERAPI_WANT_GetMIDIOutputName
 #define REAPERAPI_WANT_CreateMIDIInput
 #define REAPERAPI_WANT_CreateMIDIOutput
+#define REAPERAPI_WANT_GetNumTracks
 #define REAPERAPI_WANT_CSurf_NumTracks
 #define REAPERAPI_WANT_CSurf_TrackToID
 #define REAPERAPI_WANT_CSurf_TrackFromID
+#define REAPERAPI_WANT_CSurf_OnTrackSelection
 #define REAPERAPI_WANT_GetLastTouchedTrack
 #define REAPERAPI_WANT_CSurf_OnPlay
 #define REAPERAPI_WANT_ShowConsoleMsg

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -40,6 +40,7 @@
 #define REAPERAPI_WANT_CSurf_OnVolumeChange
 #define REAPERAPI_WANT_CSurf_OnPanChange
 #define REAPERAPI_WANT_GetPlayState
+#define REAPERAPI_WANT_Track_GetPeakInfo
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 
@@ -58,6 +59,7 @@ class BaseSurface: public IReaperControlSurface {
 	midi_Input* _midiIn = nullptr;
 	midi_Output* _midiOut = nullptr;
 	virtual void _onMidiEvent(MIDI_event_t* event) = 0;
+	virtual void _vuMixerUpdate() = 0;
 };
 
 IReaperControlSurface* createNiMidiSurface(int inDev, int outDev);


### PR DESCRIPTION
This pull request implements the Peak Level Meters on the Komplete Kontrol Keyboard. It is based on previous pull requests #7 and #9. It thus shows more changes relative to the current master which has not yet pulled #7 and #9 .

Notes:
- The meters shown on the displays of S-Series Mk2 show a dB scale. This scale is not evenly spaced, i.e. the number of pixels between e.g. the 0dB mark and the -12dB mark differs from the number of pixels between the -12dB mark and the -24dB mark and so on. Reaper reports proper peak values and also shows these values correctly on an evenly spaced scale in Reaper's on screen meters. In order to match the reading between Reaper meters on the computer screen and the keyboard's display the non-linearity of the keyboard's display scale is taken into account.
- The above will also be relevant when sending Reaper's track fader (volume) positions in upcoming feature additions (aka "volume text").
- As a future code optimization maybe I will substitute the currently used pow() function to transform the meter values by exp() which should be computationally more efficient