### PR TITLE
Volume text & Volume markers in Mixer View, Volume Callback 

### DIFF
--- a/include/reaper/WDL/db2val.h
+++ b/include/reaper/WDL/db2val.h
@@ -1,0 +1,17 @@
+#ifndef _WDL_DB2VAL_H_
+#define _WDL_DB2VAL_H_
+
+#include <math.h>
+
+#define TWENTY_OVER_LN10 8.6858896380650365530225783783321
+#define LN10_OVER_TWENTY 0.11512925464970228420089957273422
+#define DB2VAL(x) exp((x)*LN10_OVER_TWENTY)
+static inline double VAL2DB(double x)
+{
+  if (x < 0.0000000298023223876953125) return -150.0;
+  double v=log(x)*TWENTY_OVER_LN10;
+  return v<-150.0?-150.0:v;
+}
+
+
+#endif

--- a/readme.md
+++ b/readme.md
@@ -5,18 +5,20 @@
 - License: GNU General Public License version 2.0.
 - License Notes: As the original work is published under GPLv2 the updated programs are also licensed under GPLv2. May be updated to GPLv3 if copyright holder of original work agrees to update too.
 
-## Feature Integration
+## Feature Integration & Releases
 This fork is mainly a development branch aiming to continuously add functionality to ReaKontrol. 
-- New features will be merged into this fork's master @ https://github.com/brummbrum/reaKontrol
+- New features will be merged continously into this fork's master @ https://github.com/brummbrum/reaKontrol
 - Testing and calibration is done with NI S-Series Mk2 Komplete Kontrol Keyboard.
+- When a critcial amount of functionality has been reached there will be releases in a dedicated release branch.
+- Binaries are planned to be available for releases (Windows only)
 
-## Upstream Integration
-- New features are also offered to the upstream master @ https://github.com/jcsteh/reaKontrol
-- Some updated features may or may not be merged with the upstream master due to different priorities
-- The sequence in which new features are published may be different between this fork and the upstream master due to different priorities
+## Upstream Integration into Parent Repository
+- New features are also offered to the upstream repository @ https://github.com/jcsteh/reaKontrol
+- Some updated features may or may not be merged with the upstream master due to possibly different priorities
+- The sequence in which new features are published may be different between this fork and the upstream repository due to possibly different priorities
 
 ## Which fork should you use?
-- To the extent that features are integrated into the upstream master it is recommended to stick to the original branch @ https://github.com/jcsteh/reaKontrol
+- To the extent that features are integrated into the upstream master it is recommended to stick to the parent repository @ https://github.com/jcsteh/reaKontrol
 
 ## Build instructions and additional description
-- Please refer to the original branch @ https://github.com/jcsteh/reaKontrol
+- Please refer to the parent repository @ https://github.com/jcsteh/reaKontrol

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ BaseSurface::~BaseSurface() {
 }
 
 void BaseSurface::Run() {
-	this->_vuMixerUpdate(); // TEST
+	this->_peakMixerUpdate(); // ToDo: Maybe update only every 2nd call to save CPU?
 	if (!this->_midiIn) {
 		return;
 	}

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -103,8 +103,8 @@ class McuSurface: public BaseSurface {
 		this->_sendRaw(message);
 	}
 
-	void _vuMixerUpdate() override {
-		// DUMMY. This has to to with the current file structure. Maybe better to move Run() callback into niMidi.cpp and mcu.cpp
+	void _peakMixerUpdate() override {
+		// DUMMY. Currently only implemented for niMiDi (Mk2). Maybe better to move Run() callback into niMidi.cpp and mcu.cpp?
 	}
 
 	private:

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -142,10 +142,10 @@ static double KK_Mk2_Display_Transform(double x_in)
 	// Midi #107 = 0dB, #68 = -12dB, #38 = -24dB, #16 = -48dB
 	double temp;
 	temp = 0.0;
-	double a = 1.4188776691241778E+00;
-	double b = 4.1718814064260904E-03;
-	double c = 1.3365905415325063E+01;
-	temp = pow(a + b * x_in, c);
+	double a = 3.4825646584552920E+15;
+	double b = -2.4473819019771705E+04;
+	double c = 7.8669055129218032E+02;
+	temp = a * exp(b / (x_in + c)); // efficiency improvement over previous use of pow()
 	return temp;
 }
 

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -91,6 +91,7 @@ signed char convertSignedMidiValue(unsigned char value) {
 
 // The following conversion functions (C) 2006-2008 Cockos Incorporated
 // Note: Keep static for now
+// Eliminate those that will eventually not be used (e.g. volToChar)
 static double charToVol(unsigned char val)
 {
 	double pos = ((double)val*1000.0) / 127.0;
@@ -99,7 +100,7 @@ static double charToVol(unsigned char val)
 
 }
 
-static  unsigned char volToChar(double vol)
+static unsigned char volToChar(double vol)
 {
 	double d = (DB2SLIDER(VAL2DB(vol))*127.0 / 1000.0);
 	if (d < 0.0)d = 0.0;
@@ -129,11 +130,27 @@ static unsigned char panToChar(double pan)
 }
 // End of conversion functions (C) 2006-2008 Cockos Incorporated
 
-static  unsigned char vuPeakToChar(double vol)
+static double KK_Mk2_Display_Transform(double x_in)
 {
-	double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Specific calibration for KK Mk2
-	if (d < 0.0)d = 0.0; // Consider setting it to 0.5 because of KK special interpretation of the 0
-	else if (d > 127.0)d = 127.0; // Consider setting it to 126.5
+	// Scale from approx -92dB (MIDI value = #1) to +5dB (MIDI value = #127)
+	// IMPORTANT: KK Mk2 meter scale intervals are NOT linear!
+	// Midi #107 = 0dB, #68 = -12dB, #38 = -24dB, #16 = -48dB
+	double temp;
+	temp = 0.0;
+	double a = 1.4188776691241778E+00;
+	double b = 4.1718814064260904E-03;
+	double c = 1.3365905415325063E+01;
+	temp = pow(a + b * x_in, c);
+	return temp;
+}
+
+static unsigned char peakToChar(double vol)
+{
+	double d = KK_Mk2_Display_Transform(VAL2DB(vol)); // Non-linear calibration to KK Mk2
+													  // For a faster less CPU intensive calculation:
+													  // double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Approximate, linear calibration for KK Mk2
+	if (d < 0.0)d = 0.0; 
+	else if (d > 127.0)d = 127.0; 
 
 	return (unsigned char)(d + 0.5);
 }
@@ -240,6 +257,12 @@ class NiMidiSurface: public BaseSurface {
 				break;
 			case CMD_NAV_TRACKS:
 				// Value is -1 or 1.
+				// ---------------------------- ISSUE --------------------------------------------------------
+				// Reaper's built in actions will not reliably got to next/previous track relative to currently SELECTED track!
+				// Rather, these actions are relative to last TOUCHED track. E.g. if volume fader is changed on a non selected track
+				// and then we navigate the new track will be next to the track with the volume fader touched
+				// => Use dedicated track navigation via API, not actions
+				// -------------------------------------------------------------------------------------------
 				Main_OnCommand(value == 1 ?
 					40285 : // Track: Go to next track
 					40286, // Track: Go to previous track
@@ -299,20 +322,14 @@ class NiMidiSurface: public BaseSurface {
 		}
 	}
 
-	void _vuMixerUpdate() override {
-		// VU meters		
-		char vuBank[17]; // INIT??? = { 0 };
-		int j = 0;
-		double peakValue = 0;
+	void _peakMixerUpdate() override {
+		// Peak meters. Note: Reaper reports peak, NOT VU	
 
-		//ToDo: Peak levels of muted tracks should NOT be polled at all
-		//ToDo: Calibration to 0dB. If we calibrate in conversion function (~900.0 vs 1000.0 we are off at low levels)
-		//       maybe calibrate before calling conversion or in first WDL conversion VAL2DB
-		//       TRY FIRST: Use directly VAL2DB conversion
-		//ToDo: Clean up array Initialization , stop byte, array size, CMD_SEL_TRACK_PARAMS_CHANGED
-		
-		vuBank[0] = 1; // there will alway be a master track
-		vuBank[1] = 1;
+		// ToDo: Peak Hold in KK display shall be erased when changing bank or when no signal at all
+		// ToDo: Explore the necessity of CMD_SEL_TRACK_PARAMS_CHANGED and if last parameter (string) shall be the last track in bank
+		char peakBank[17] = { 0 }; // For some reason there must be this additional char peakBank[16] and it must be set to 0
+		int j = 0;
+		double peakValue = 0;		
 		int numInBank = 0;
 		int bankEnd = this->_bankStart + BANK_NUM_TRACKS - 1;
 		int numTracks = CSurf_NumTracks(false); // If we ever want to show just MCP tracks in KK Mixer View (param) must be (true)
@@ -325,28 +342,38 @@ class NiMidiSurface: public BaseSurface {
 				break;
 			}
 			j = 2 * numInBank;
-			peakValue = Track_GetPeakInfo(track, 0); // left channel
-			if (peakValue == 0) {
-				// No log conversion necessary
-				vuBank[j] = 1; // if 0 then channels further to the right are ignored by KK display
+			// Muted tracks still report peak levels => ignore these
+			if (*(bool*)GetSetMediaTrackInfo(track, "B_MUTE", nullptr)) {
+				peakBank[j] = 1;
+				peakBank[j+1] = 1;
 			}
 			else {
-				vuBank[j] = vuPeakToChar(peakValue);
-				if (vuBank[j] == 0) { vuBank[j] = 1; } // if 0 then channels further to the right are ignored by KK display
+				peakValue = Track_GetPeakInfo(track, 0); // left channel
+				if (peakValue < 0.0000000298023223876953125) {
+					// No log conversion necessary if < -150dB
+					peakBank[j] = 1; // if 0 then channels further to the right are ignored by KK display
+				}
+				else {
+					peakBank[j] = peakToChar(peakValue);
+					if (peakBank[j] == 0) { peakBank[j] = 1; } // if 0 then channels further to the right are ignored by KK display
+				}
+				peakValue = Track_GetPeakInfo(track, 1); // right channel
+				if (peakValue < 0.0000000298023223876953125) {
+					// No log conversion necessary if < -150dB
+					peakBank[j + 1] = 1; // if 0 then channels further to the right are ignored by KK display
+				}
+				else {
+					peakBank[j + 1] = peakToChar(peakValue);
+					if (peakBank[j + 1] == 0) { peakBank[j + 1] = 1; } // if 0 then channels further to the right are ignored by KK display
+				}
 			}
-			peakValue = Track_GetPeakInfo(track, 1); // right channel
-			if (peakValue == 0) {
-				// No log conversion necessary
-				vuBank[j+1] = 1; // if 0 then channels further to the right are ignored by KK display
-			}
-			else {
-				vuBank[j+1] = vuPeakToChar(peakValue);
-				if (vuBank[j+1] == 0) { vuBank[j+1] = 1; } // if 0 then channels further to the right are ignored by KK display
-			}
-		}
-		vuBank[16] = 0; // JUST A TEST - it seems a sort of stop bit/byte is needed here. See also initialization above
-		this->_sendSysex(CMD_TRACK_VU, 2, 0, vuBank); // do the params have anything to do with calibration?
-		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all? Maybe we have to reference last track in bank to indicate end of updates?
+		}	
+		this->_sendSysex(CMD_TRACK_VU, 2, 0, peakBank); 
+		/*
+		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all?
+															  // Maybe we have to reference last track in bank to indicate end of updates?
+															  // Or, if the meter for only one track shall be changed this is indicated here
+		*/
 	}
 
 	private:
@@ -404,9 +431,9 @@ class NiMidiSurface: public BaseSurface {
 		}
 		MediaTrack* track = CSurf_TrackFromID(id, false);
 		int iSel = 1; // "Select"
-		// If we rather wanted to "Toggle" than just "Select" we would use:
-		// int iSel = 0;
-		// int iSel = *(int*)GetSetMediaTrackInfo(track, "I_SELECTED", nullptr) ? 0 : 1; 
+					  // If we rather wanted to "Toggle" than just "Select" we would use:
+					  // int iSel = 0;
+					  // int iSel = *(int*)GetSetMediaTrackInfo(track, "I_SELECTED", nullptr) ? 0 : 1; 
 		ClearSelected(); 
 		GetSetMediaTrackInfo(track, "I_SELECTED", &iSel);		
 	}

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -256,7 +256,7 @@ class NiMidiSurface: public BaseSurface {
 
 	void _allMixerUpdate() {
 		int numInBank = 0;
-		int bankEnd = this->_bankStart + BANK_NUM_TRACKS;
+		int bankEnd = this->_bankStart + BANK_NUM_TRACKS - 1; // avoid ambiguity: track counting always zero based
 		int numTracks = CSurf_NumTracks(false); // If we ever want to show just MCP tracks in KK Mixer View (param) must be (true)
 		if (bankEnd > numTracks) {
 			bankEnd = numTracks;
@@ -329,7 +329,7 @@ class NiMidiSurface: public BaseSurface {
 		if (!track) {
 			return;
 		}
-		CSurf_OnVolumeChange(track, dvalue * 0.01, true); 
+		CSurf_OnVolumeChange(track, dvalue * 0.007874, true); // scaling by dividing by 127 (0.007874) 
 	}
 
 	void _onKnobPanChange(unsigned char command, signed char value) {
@@ -339,7 +339,7 @@ class NiMidiSurface: public BaseSurface {
 		if (!track) {
 			return;
 		}
-		CSurf_OnPanChange(track, dvalue * 0.001, true);
+		CSurf_OnPanChange(track, dvalue * 0.00098425, true); // scaling by dividing by 127*8 (0.00098425)
 	}
 
 	void _sendCc(unsigned char command, unsigned char value) {

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -7,7 +7,6 @@
  * License: GNU General Public License version 2.0
  */
 
-#define DEBUG_DIAGNOSTICS
 #define BASIC_DIAGNOSTICS
 
 #include <string>
@@ -214,17 +213,6 @@ class NiMidiSurface: public BaseSurface {
 		unsigned char& command = event->midi_message[1];
 		unsigned char& value = event->midi_message[2];
 		
-#ifdef DEBUG_DIAGNOSTICS
-		ostringstream s;
-		s << "Diagnostic: MIDI " << showbase << hex
-			<< (int)event->midi_message[0] << " "
-			<< (int)event->midi_message[1] << " "
-			<< (int)event->midi_message[2] << " Focus Track "
-			<< g_trackInFocus << " Bank Start "
-			<< this->_bankStart << endl;
-		ShowConsoleMsg(s.str().c_str());
-#endif
-
 		switch (command) {
 			case CMD_HELLO:
 				this->_protocolVersion = value;

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -262,6 +262,7 @@ class NiMidiSurface: public BaseSurface {
 				// Rather, these actions are relative to last TOUCHED track. E.g. if volume fader is changed on a non selected track
 				// and then we navigate the new track will be next to the track with the volume fader touched
 				// => Use dedicated track navigation via API, not actions
+				// OK: Ready for pulling a fix
 				// -------------------------------------------------------------------------------------------
 				Main_OnCommand(value == 1 ?
 					40285 : // Track: Go to next track

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -7,6 +7,7 @@
  * License: GNU General Public License version 2.0
  */
 
+#define DEBUG_DIAGNOSTICS
 #define BASIC_DIAGNOSTICS
 
 #include <string>
@@ -213,6 +214,17 @@ class NiMidiSurface: public BaseSurface {
 		unsigned char& command = event->midi_message[1];
 		unsigned char& value = event->midi_message[2];
 		
+#ifdef DEBUG_DIAGNOSTICS
+		ostringstream s;
+		s << "Diagnostic: MIDI " << showbase << hex
+			<< (int)event->midi_message[0] << " "
+			<< (int)event->midi_message[1] << " "
+			<< (int)event->midi_message[2] << " Focus Track "
+			<< g_trackInFocus << " Bank Start "
+			<< this->_bankStart << endl;
+		ShowConsoleMsg(s.str().c_str());
+#endif
+
 		switch (command) {
 			case CMD_HELLO:
 				this->_protocolVersion = value;

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -132,8 +132,8 @@ static unsigned char panToChar(double pan)
 static  unsigned char vuPeakToChar(double vol)
 {
 	double d = (DB2SLIDER(VAL2DB(vol) - 52.0));  // Specific calibration for KK Mk2
-	if (d < 0.0)d = 0.0;
-	else if (d > 127.0)d = 127.0;
+	if (d < 0.0)d = 0.0; // Consider setting it to 0.5 because of KK special interpretation of the 0
+	else if (d > 127.0)d = 127.0; // Consider setting it to 126.5
 
 	return (unsigned char)(d + 0.5);
 }
@@ -345,7 +345,7 @@ class NiMidiSurface: public BaseSurface {
 			}
 		}
 		vuBank[16] = 0; // JUST A TEST - it seems a sort of stop bit/byte is needed here. See also initialization above
-		this->_sendSysex(CMD_TRACK_VU, 2, 2, vuBank); // do the params have anything to do with calibration?
+		this->_sendSysex(CMD_TRACK_VU, 2, 0, vuBank); // do the params have anything to do with calibration?
 		this->_sendSysex(CMD_SEL_TRACK_PARAMS_CHANGED, 0, 0); // Needed at all? Maybe we have to reference last track in bank to indicate end of updates?
 	}
 

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -62,7 +62,7 @@ class BaseSurface: public IReaperControlSurface {
 	midi_Input* _midiIn = nullptr;
 	midi_Output* _midiOut = nullptr;
 	virtual void _onMidiEvent(MIDI_event_t* event) = 0;
-	virtual void _vuMixerUpdate() = 0;
+	virtual void _peakMixerUpdate() = 0;
 };
 
 IReaperControlSurface* createNiMidiSurface(int inDev, int outDev);

--- a/src/reaKontrol.h
+++ b/src/reaKontrol.h
@@ -41,8 +41,11 @@
 #define REAPERAPI_WANT_CSurf_OnPanChange
 #define REAPERAPI_WANT_GetPlayState
 #define REAPERAPI_WANT_Track_GetPeakInfo
+#define REAPERAPI_WANT_DB2SLIDER
+#define REAPERAPI_WANT_SLIDER2DB
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
+#include <reaper/WDL/db2val.h>
 
 const std::string getKkInstanceName(MediaTrack* track, bool stripPrefix=false);
 


### PR DESCRIPTION
Based on pull request #10 as it uses functions introduced there, namely the calibrated meter conversion to set the volume marker precisely matched to the labels in both the KK keyboard display and Reaper's meters.
Volume text matches meter readings correctly.

Immediate display updates for volume as we are (slowly) moving out of the "abusive" call to update the entire bank from within track selection change.