### PR TITLE
Make it possible to alter the scaling of parameters in ReaKontrol FX maps.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,8 +77,8 @@ ReaComp: # This is optional and overrides the FX name reported to users.
 --- # Page break. The remaining knobs on this page will be unassigned.
 [mix] # This is a section name for the following knobs.
 6 # Parameter 6 will be mapped to the first knob on the second page.
-7 /8 penguin # Adjustments will be 8 times smaller than usual for this parameter.
-8 *8 goat # Adjustments will be 8 times larger than usual for this parameter.
+10 /8 dry dB # Adjustments will be 8 times smaller than usual for this parameter.
+11 *8 # Adjustments will be 8 times larger than usual for this parameter.
 ```
 
 ReaKontrol can help you create these maps.

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,8 @@ ReaComp: # This is optional and overrides the FX name reported to users.
 --- # Page break. The remaining knobs on this page will be unassigned.
 [mix] # This is a section name for the following knobs.
 6 # Parameter 6 will be mapped to the first knob on the second page.
+7 /8 penguin # Adjustments will be 8 times smaller than usual for this parameter.
+8 *8 goat # Adjustments will be 8 times larger than usual for this parameter.
 ```
 
 ReaKontrol can help you create these maps.

--- a/src/fxMap.h
+++ b/src/fxMap.h
@@ -23,6 +23,7 @@ class FxMap {
 	int getReaperParam(int mapParam) const;
 	int getMapParam(int reaperParam) const;
 	std::string getParamName(int mapParam) const;
+	double getParamMultiplier(int mapParam) const;
 	std::string getSection(int mapParam) const;
 	std::string getSectionsForPage(int mapParam) const;
 
@@ -35,6 +36,7 @@ class FxMap {
 	int _fx = -1;
 	std::vector<int> _reaperParams;
 	std::map<int, std::string> _paramNames;
+	std::map<int, double> _paramMultipliers;
 	std::map<int, int> _mapParams;
 	std::map<int, std::string> _sections;
 };

--- a/src/niMidi.cpp
+++ b/src/niMidi.cpp
@@ -978,7 +978,7 @@ class NiMidiSurface: public BaseSurface {
 			val = TrackFX_GetParamNormalized(this->_lastSelectedTrack,
 				this->_selectedFx, param);
 		}
-		val += change;
+		val += change * this->_fxMap.getParamMultiplier(mp);
 		val = clamp(val, 0.0, 1.0);
 		TrackFX_SetParamNormalized(this->_lastSelectedTrack, this->_selectedFx, param,
 			val);


### PR DESCRIPTION
For example, in an rkfm file:

```
7 /8 penguin # Adjustments will be 8 times smaller than usual for this parameter.
8 *8 goat # Adjustments will be 8 times larger than usual for this parameter.
```

Completely untested. Just pushing this for now so I don't lose it while I have 0 motivation to test things. :)